### PR TITLE
Fix: Select default currency as saved in localStorage

### DIFF
--- a/src/components/IncomeForm.tsx
+++ b/src/components/IncomeForm.tsx
@@ -107,7 +107,7 @@ export function IncomeForm({ defaultValues, onSubmit }: IncomeFormProps) {
                     <FormLabel>Currency</FormLabel>
                     <Select 
                       onValueChange={field.onChange} 
-                      defaultValue={field.value}
+                      value={field.value}
                     >
                       <FormControl>
                         <SelectTrigger>


### PR DESCRIPTION
Fix: Select default currency based on value saved in localStorage

This update ensures that the default currency is automatically selected according to the user's previously saved preference in localStorage.
If no saved currency is found, the system will fallback to the default option.