### PR TITLE
Add ability to edit goals

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "build": "npm install && npm run build"
+  }
+}

--- a/src/components/GoalForm.tsx
+++ b/src/components/GoalForm.tsx
@@ -1,4 +1,3 @@
-
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
@@ -16,6 +15,7 @@ import { z } from "zod";
 interface GoalFormProps {
   income: IncomeDetails;
   onSubmit: (goal: Goal) => void;
+  editingGoal?: Goal | null;
 }
 
 const goalFormSchema = z.object({
@@ -26,59 +26,58 @@ const goalFormSchema = z.object({
   impact: z.coerce.number().min(1).max(5, "Impact must be between 1 and 5"),
 });
 
-export function GoalForm({ income, onSubmit }: GoalFormProps) {
-  const [selectedType, setSelectedType] = useState<"product" | "experience">("product");
+export function GoalForm({ income, onSubmit, editingGoal }: GoalFormProps) {
+  const [selectedType, setSelectedType] = useState<"product" | "experience">(
+    editingGoal?.type || "product"
+  );
 
   const form = useForm<z.infer<typeof goalFormSchema>>({
     resolver: zodResolver(goalFormSchema),
     defaultValues: {
-      name: "",
-      cost: 0,
-      type: "product",
-      years: 5,
-      impact: 2,
+      name: editingGoal?.name || "",
+      cost: editingGoal?.cost || 0,
+      type: editingGoal?.type || "product",
+      years: editingGoal?.years || 5,
+      impact: editingGoal?.impact || 2,
     },
   });
 
   const handleSubmit = (data: z.infer<typeof goalFormSchema>) => {
-    // Ensure all required properties are set for Goal type
     const goal: Goal = {
-      id: crypto.randomUUID(),
+      id: editingGoal?.id || crypto.randomUUID(),
       name: data.name,
       cost: data.cost,
       type: data.type,
       years: data.years,
       impact: data.impact as 1 | 2 | 3 | 4 | 5,
-      timestamp: Date.now(),
+      timestamp: editingGoal?.timestamp || Date.now(),
     };
 
     onSubmit(goal);
   };
 
-  // Handle radio button change
   const handleTypeChange = (value: "product" | "experience") => {
     setSelectedType(value);
-
-    // Reset the years field based on type
     form.setValue("years", value === "product" ? 5 : 20);
     form.setValue("impact", 2);
   };
 
-  const impactOptions = selectedType === "product"
-    ? [
-      { value: 1, label: "Don't need it" },
-      { value: 2, label: "Nice to have" },
-      { value: 3, label: "Really want it" },
-      { value: 4, label: "Dying for it" },
-      { value: 5, label: "Life changing" },
-    ]
-    : [
-      { value: 1, label: "Like any other day" },
-      { value: 2, label: "Think of it fondly" },
-      { value: 3, label: "Enjoy it a lot" },
-      { value: 4, label: "Cherished memory" },
-      { value: 5, label: "Once in a lifetime" },
-    ];
+  const impactOptions =
+    selectedType === "product"
+      ? [
+          { value: 1, label: "Don't need it" },
+          { value: 2, label: "Nice to have" },
+          { value: 3, label: "Really want it" },
+          { value: 4, label: "Dying for it" },
+          { value: 5, label: "Life changing" },
+        ]
+      : [
+          { value: 1, label: "Like any other day" },
+          { value: 2, label: "Think of it fondly" },
+          { value: 3, label: "Enjoy it a lot" },
+          { value: 4, label: "Cherished memory" },
+          { value: 5, label: "Once in a lifetime" },
+        ];
 
   return (
     <Card className="w-full max-w-md mx-auto animate-fade-in">

--- a/src/components/GoalHistory.tsx
+++ b/src/components/GoalHistory.tsx
@@ -1,4 +1,3 @@
-
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -11,16 +10,17 @@ import {
 } from "@/components/ui/table";
 import { Currency, GoalResult } from "@/types";
 import { formatCurrency, getVerdictDetails } from "@/utils/calculations";
-import { Trash } from "lucide-react";
+import { Trash, Edit } from "lucide-react";
 import {useTheme} from "next-themes";
 
 interface GoalHistoryProps {
   goals: GoalResult[];
   currency: Currency;
   onClearHistory: () => void;
+  onEditGoal: (goal: GoalResult) => void;
 }
 
-export function GoalHistory({ goals, currency, onClearHistory }: GoalHistoryProps) {
+export function GoalHistory({ goals, currency, onClearHistory, onEditGoal }: GoalHistoryProps) {
   const { theme } = useTheme();
 
   if (goals.length === 0) {
@@ -44,6 +44,7 @@ export function GoalHistory({ goals, currency, onClearHistory }: GoalHistoryProp
               <TableHead>Cost</TableHead>
               <TableHead>Score</TableHead>
               <TableHead className="text-right">Verdict</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -66,6 +67,11 @@ export function GoalHistory({ goals, currency, onClearHistory }: GoalHistoryProp
                     >
                       {verdictDetails.emoji} {verdictDetails.title}
                     </span>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button variant="outline" size="sm" onClick={() => onEditGoal(goal)}>
+                      <Edit className="h-4 w-4 mr-2" /> Edit
+                    </Button>
                   </TableCell>
                 </TableRow>
               );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,3 @@
-
 import { IncomeForm } from "@/components/IncomeForm";
 import { GoalForm } from "@/components/GoalForm";
 import { ResultCard } from "@/components/ResultCard";
@@ -18,7 +17,8 @@ const Index = () => {
   const [savingsBreakdown, setSavingsBreakdown] = useState<SavingsBreakdown | null>(null);
   const [currentResult, setCurrentResult] = useState<GoalResult | null>(null);
   const [goalHistory, setGoalHistory] = useState<GoalResult[]>([]);
-  
+  const [editingGoal, setEditingGoal] = useState<Goal | null>(null);
+
   // Load saved data on component mount
   useEffect(() => {
     const savedIncome = getIncomeFromStorage();
@@ -63,10 +63,17 @@ const Index = () => {
     trackGoalSaved(goal, incomeDetails.currency);
     
     setStage('result');
+    setEditingGoal(null);
+  };
+
+  const handleEditGoal = (goal: Goal) => {
+    setEditingGoal(goal);
+    setStage('goal');
   };
   
   const handleReset = () => {
     setStage('goal');
+    setEditingGoal(null);
   };
   
   const handleClearHistory = () => {
@@ -101,6 +108,7 @@ const Index = () => {
           <GoalForm 
             income={incomeDetails} 
             onSubmit={handleGoalSubmit} 
+            editingGoal={editingGoal}
           />
         )}
         
@@ -116,6 +124,7 @@ const Index = () => {
               goals={goalHistory}
               currency={incomeDetails.currency}
               onClearHistory={handleClearHistory}
+              onEditGoal={handleEditGoal}
             />
           </>
         )}


### PR DESCRIPTION
Add functionality to edit goals after creation.

* **Index.tsx**
  - Add `editingGoal` state variable to track the goal being edited.
  - Add `handleEditGoal` function to set the `editingGoal` state.
  - Pass `editingGoal` and `handleEditGoal` as props to `GoalForm`.
  - Update `handleGoalSubmit` to handle both new and edited goals.
  - Update `handleReset` to reset the `editingGoal` state.

* **GoalForm.tsx**
  - Add `editingGoal` prop to receive the goal being edited.
  - Update `useForm` to set default values based on `editingGoal`.
  - Update `handleSubmit` to handle both new and edited goals.

* **GoalHistory.tsx**
  - Add `onEditGoal` prop to handle goal editing.
  - Add an edit button to each goal row to trigger editing.

* **.devcontainer/devcontainer.json**
  - Add devcontainer configuration file with build tasks.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/championswimmer/worth-it-calculator-app/pull/3?shareId=5b765636-4518-47c1-b1d4-6fd42600d5b8).